### PR TITLE
Migration to redis

### DIFF
--- a/eden/block.py
+++ b/eden/block.py
@@ -20,8 +20,8 @@ class BaseBlock(object):
         self.data_model = None
         self.progress = False
 
-    def get_progress_bar(self, results_dir, token = None, show_bar = False):
-        self.progress_tracker = ProgressTracker(token = token, results_dir = results_dir)
+    def get_progress_bar(self, token: str, result_storage):
+        self.progress_tracker = ProgressTracker(token = token, result_storage = result_storage)
         return self.progress_tracker
 
     def create_default_data_fields(self):
@@ -35,7 +35,7 @@ class BaseBlock(object):
 
         for key, value in self.default_args.items():
             if isinstance(value, Image):
-                self.default_args[key] = value.__call__()
+                self.default_args[key] = value.encode()
     
     def build_pydantic_model(self):
         """

--- a/eden/config_wrapper.py
+++ b/eden/config_wrapper.py
@@ -1,6 +1,5 @@
 from .progress_tracker import ProgressTracker
-
-from .utils import load_json_as_dict, parse_for_taking_request
+from .data_handlers import Encoder, Decoder
 
 class ConfigWrapper(object):
     """
@@ -17,13 +16,16 @@ class ConfigWrapper(object):
         progress (ProgressTracker, optional): If provided, can be used to update the progress of the job. Defaults to None.
         token (str, optional): Unique identifier behind each task run. Defaults to None.
     """
-    def __init__(self, data: dict, filename: str, gpu: str, progress: ProgressTracker = None, token :str = None):
+    def __init__(self, data: dict, gpu: str, progress: ProgressTracker = None, token :str = None, result_storage = None):
         
         self.data = data
-        self.filename = filename
         self.gpu = gpu
         self.progress = progress
         self.token = token
+
+        self.decoder = Decoder()
+        self.result_storage = result_storage
+        
         self.__key_to_look_for_in_json_file__ = 'config'
 
     def __getitem__(self, idx):
@@ -43,7 +45,8 @@ class ConfigWrapper(object):
         """
         something_changed = False
 
-        d = parse_for_taking_request(load_json_as_dict(filename= self.filename))
+        d = self.decoder.decode(self.result_storage.get(self.token))
+
         data = d[self.__key_to_look_for_in_json_file__]
         
         if data != self.data:

--- a/eden/datatypes.py
+++ b/eden/datatypes.py
@@ -1,23 +1,36 @@
 from .image_utils import encode
 
 class BaseDataType(object):
-    def __init__(self):
-        self.type = 'eden.datatypes.BaseDataType'
-        self.data = ''
-    
+    def __init__(self, data = None):
+        """
+        A base abstraction over which all other eden's datatypes would be 
+        based on top of. n
 
-    def __call__(self):
+        Args:
+            data: Defaults to None.
+        """
+        self.type = 'eden.datatypes.BaseDataType'
+        self.data = data
+
+    def encode(self):
         return {
             'data': self.data,
             'type': self.type
         }
 
 
-
 class Image(BaseDataType):
     def __init__(self, image = None):
+        """
+        Wrapper to store/send images to and fro from an eden server.
+
+        Args:
+            image (numpy.array or PIL.Image or str, optional): Image to be stored. Defaults to None.
+        """
         super().__init__()
+
         self.type = 'eden.datatypes.Image'
+
         if image is not None:
             self.data = encode(image)
         else:

--- a/eden/progress_tracker.py
+++ b/eden/progress_tracker.py
@@ -1,24 +1,22 @@
 from tqdm import tqdm 
-from .utils import (
-    get_filename_from_token, 
-    load_json_from_token,
-    write_json
-)
-
+from .result_storage import ResultStorage
 
 class ProgressTracker():
-    def __init__(self, results_dir, token = None):
+    def __init__(self, token: str, result_storage: ResultStorage):
         self.value = 0.0
         self.token = token
-        self.results_dir = results_dir
-        self.filename = get_filename_from_token(token = token, results_dir = self.results_dir)
+        self.result_storage = result_storage
 
     def update(self, n):
 
         self.value += n
 
-        d = load_json_from_token(token = self.token, results_dir = self.results_dir)
+        output_from_storage = self.result_storage.get(token = self.token)
+        output_from_storage['progress'] = self.value  
 
-        d['status']['progress'] = self.value
+        success = self.result_storage.add(
+            encoded_results = output_from_storage,
+            token = self.token
+        )
 
-        write_json(dictionary = d, path = self.filename)
+        return success

--- a/eden/utils.py
+++ b/eden/utils.py
@@ -1,97 +1,21 @@
-from .datatypes import Image
-from .image_utils import decode
-
-
 import os
-import json
 import time
+import json
 import secrets, string
-
-def parse_for_sending_request(config: dict = {}):
-    for key, value in config.items():
-        
-        if isinstance(value, Image):
-            config[key] = value.__call__()
-
-    return config
-
-def parse_for_taking_request(response: dict = {}):
-
-    for key, value in response.items():
-
-        if isinstance(value, dict):
-            if 'type' in list(value.keys()):
-                
-                if value['type'] == 'eden.datatypes.Image':
-                    response[key] = decode(response[key]['data'])
-
-                '''
-                as we add more datatypes, just add them in here like: 
-
-                if value['type'] == 'eden.datatypes.some_type':
-                    response[key] = decode_some_type(response[key]['data'])
-
-                '''
-    return response
-
-def find_and_decode_images(d: dict):
-
-    for key, value in d.items():
-        
-        if isinstance(value, dict):
-
-            if 'type' in list(value.keys()):
-                
-                if value['type'] == 'eden.datatypes.Image':
-                    d[key] = decode(d[key]['data'])
-    return d
-        
-
-
-def parse_response_after_run(response: dict):
-    
-    keys_to_parse = [
-        'config',
-        'output'
-    ]
-
-    for key in list(keys_to_parse):
-        if key in list(response.keys()):
-            response[key] = find_and_decode_images(d = response[key])
-
-    return response
-
-def write_json(dictionary: dict, path:str):
-    with open(path, "w") as write_file:
-        json.dump(dictionary, write_file, indent=4)
-
-def update_json(dictionary: dict, path:str):
-    data = load_json_as_dict(path)
-    for key, value in dictionary.items():
-        data[key] = value
-    write_json(data, path)
 
 def generate_random_string(len):
     x = ''.join(secrets.choice(string.ascii_lowercase + string.digits) for i in range(len))
     return x
 
-def make_id(username):
-    id = username + "_"+ str(int(time.time())) + "_" + generate_random_string(len = 8)
-    return id
+def dict_to_bytes(dictionary: dict): 
 
-def get_filename_from_token(results_dir, token):
-    filename = results_dir + "/" + token + '.json'
-    return filename
+    dict_in_bytes = json.dumps(dictionary).encode('utf-8')
+    return dict_in_bytes
 
-def load_json_as_dict(filename):
-    with open(filename) as json_file:
-        data = json.load(json_file)
-    
-    return data 
-
-def load_json_from_token(token, results_dir):
-    filename = get_filename_from_token(token = token, results_dir = results_dir)
-    return load_json_as_dict(filename)
+def bytes_to_dict(dict_in_bytes): 
+    dict_str = dict_in_bytes.decode("UTF-8")
+    dict_from_str = json.loads(dict_str)
+    return dict_from_str
 
 def stop_everything_gracefully(t):
     time.sleep(t)


### PR DESCRIPTION
This PR marks our migration from using json files to utilizing redis for data storage/queue tracking 

Primary changes made:

- Eden now directly fetches data from celery's redis database to determine if a task is queued/running/complete/failed
- So to store results + config + progress in an updatable (`/update`) way, we'll be using `db: 1` of the same redis instance used by celery. By default, celery uses `db: 0`
- The only file that eden now optionally makes is the `logfile`. No more json files :partying_face: 

In theory, multiple 'replicas/instances' can now work on the same queue and also dump their results (or failures) into one single redis db/storage/whatever it's called. 