### PR TITLE
chore: enable late ack

### DIFF
--- a/eden/hosting.py
+++ b/eden/hosting.py
@@ -121,6 +121,11 @@ def host_block(block, port = 8080, host = '0.0.0.0', max_num_workers = 4, redis_
     celery_app.conf.worker_prefetch_multiplier = 1
 
     """
+    task messages will be acknowledged after the task has been executed 
+    """
+    celery_app.conf.task_acks_late = True
+
+    """
     Initiating GPUAllocator only if requires_gpu is True
     """
     if requires_gpu == True:


### PR DESCRIPTION
The way we scale eden involves replicas of (API+celery+worker) sharing the same redis queue.  While the replicas may come and go, we want every new job to be handled by any of available workers.

Currently the way it works is that any given worker will ACK the current message _AND_ the next one in the queue, effectively making the next one wait for execution, regardless of any other free worker.

By enabling late ack, the worker won't ACK the current nor the next one _unless current execution is done_, effectively leaving alone the queue, so potential other workers can pick up.

Fix for https://github.com/abraham-ai/eden/issues/23