### PR TITLE
add a simple webhook sender

### DIFF
--- a/eden/hosting.py
+++ b/eden/hosting.py
@@ -35,8 +35,6 @@ tool to allocate gpus on queued tasks
 """
 from .gpu_allocator import GPUAllocator
 
-from .webhook import WebHook
-
 
 def host_block(
     block,
@@ -49,8 +47,7 @@ def host_block(
     log_level="warning",
     logfile="logs.log",
     exclude_gpu_ids: list = [],
-    remove_result_on_fetch = False,
-    webhook: WebHook = None
+    remove_result_on_fetch = False
 ):
     """
     Use this to host your eden.Block on a server. Supports multiple GPUs and queues tasks automatically with celery.
@@ -299,10 +296,6 @@ def host_block(
                 gpu_allocator.set_as_free(name=gpu_name)
 
             success = block.write_results(output=output, token=token)
-
-            print('sending webhook!!')
-            if webhook is not None:
-                resp = webhook(output)
 
             return success  ## return None because results go to result_storage instead
 

--- a/eden/hosting.py
+++ b/eden/hosting.py
@@ -35,6 +35,8 @@ tool to allocate gpus on queued tasks
 """
 from .gpu_allocator import GPUAllocator
 
+from .webhook import WebHook
+
 
 def host_block(
     block,
@@ -47,7 +49,8 @@ def host_block(
     log_level="warning",
     logfile="logs.log",
     exclude_gpu_ids: list = [],
-    remove_result_on_fetch = False
+    remove_result_on_fetch = False,
+    webhook: WebHook = None
 ):
     """
     Use this to host your eden.Block on a server. Supports multiple GPUs and queues tasks automatically with celery.
@@ -296,6 +299,10 @@ def host_block(
                 gpu_allocator.set_as_free(name=gpu_name)
 
             success = block.write_results(output=output, token=token)
+
+            print('sending webhook!!')
+            if webhook is not None:
+                resp = webhook(output)
 
             return success  ## return None because results go to result_storage instead
 

--- a/eden/webhook.py
+++ b/eden/webhook.py
@@ -1,5 +1,3 @@
-from argparse import ONE_OR_MORE
-from base64 import encode
 import json
 import requests
 

--- a/eden/webhook.py
+++ b/eden/webhook.py
@@ -1,0 +1,17 @@
+from argparse import ONE_OR_MORE
+from base64 import encode
+import json
+import requests
+
+from typing import Callable
+
+class WebHook:
+    def __init__(self, url: str, encode_fn : Callable = None) -> None:
+        self.url = url
+        self.encode_fn = encode_fn
+
+    def __call__(self, data: dict):
+        if self.encode_fn is not None:
+            data = self.encode_fn(data)
+        r = requests.post(self.url, data=json.dumps(data), headers={'Content-Type': 'application/json'})
+        return r


### PR DESCRIPTION
can be utilized for a pub-sub model
**Note:** this feature has not been heavily tested yet, so it is recommended to proceed with caution

Example:
```python
from eden.webhook import WebHook

## encode_fn is a Callable which can be used to encode stuff like images to be json serializable before they're sent
## for now, let's try to only send non-image stuff while I standardise the WebHook wrapper for eden to support all datatypes
webhook = WebHook(url = "https://webhook.site/7df567ff-03a7-437c-b848-13c78a833e91", encode_fn = None)

data = {
    'message': 'hello'
}

resp = webhook(data) ## sending data
```