### PR TITLE
try/except block to handle use-cases without git

### DIFF
--- a/eden/hosting.py
+++ b/eden/hosting.py
@@ -462,7 +462,7 @@ def host_block(
         Returns name and active commit hash of the generator
         """
         try:
-            repo = git.Repo(search_parent_directories=True, bare=True)
+            repo = git.Repo(search_parent_directories=True)
             name = repo.remotes.origin.url.split('.git')[0].split('/')[-1]
             sha = repo.head.object.hexsha
         except git.exc.InvalidGitRepositoryError:

--- a/eden/hosting.py
+++ b/eden/hosting.py
@@ -461,10 +461,13 @@ def host_block(
         """
         Returns name and active commit hash of the generator
         """
-
-        repo = git.Repo(search_parent_directories=True)
-        name = repo.remotes.origin.url.split('.git')[0].split('/')[-1]
-        sha = repo.head.object.hexsha
+        try:
+            repo = git.Repo(search_parent_directories=True, bare=True)
+            name = repo.remotes.origin.url.split('.git')[0].split('/')[-1]
+            sha = repo.head.object.hexsha
+        except git.exc.InvalidGitRepositoryError:
+            name = "repo-less-eden"
+            sha = "none"
 
         response = {
             "name": name,


### PR DESCRIPTION
ran into an issue trying to build a container (which did not depend on git cloning an "eden app"), and currently the code will bail out on `git.Repo`. This proposed change allows for overriding the need for `git` to be installed by setting an environment variable, and allows for successful server responses without it.