### PR TITLE
explicit type imports to help robustness of isinstance check for images

### DIFF
--- a/eden/image_utils.py
+++ b/eden/image_utils.py
@@ -2,7 +2,9 @@ import PIL
 import cv2
 import base64
 import numpy as np
-import PIL.Image
+from PIL.Image import Image as ImageFile
+from PIL.JpegImagePlugin import JpegImageFile
+from PIL.PngImagePlugin import PngImageFile
 from PIL import Image
 from io import BytesIO
 
@@ -42,9 +44,9 @@ def encode(image):
         or isinstance(
             image,
             (
-                PIL.JpegImagePlugin.JpegImageFile,
-                PIL.PngImagePlugin.PngImageFile,
-                PIL.Image.Image,
+                JpegImageFile,
+                PngImageFile,
+                ImageFile,
             ),
         )
     ):


### PR DESCRIPTION
I still don't entirely have an explanation for this, but when I ran `eden` within docker, the client script that was working fine locally started running into the following error when the IP was changed to the container's address:

```
File "/home/eden/.local/lib/python3.10/site-packages/eden/datatypes.py", line 33, in __init__
    self.data = encode(image)
  File "/home/eden/.local/lib/python3.10/site-packages/eden/image_utils.py", line 41, in encode
    or isinstance(
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

For context, `eden-python` was installed with `pip` in the docker image. When I sent a request to the container (from a client script running locally), I was getting "failed" statuses, and the logs of the container contained the error above printed to `stdout` (I set `logfile=None` in my `server.py`).

I added the proposed modified `image_utils.py` file into the build as a test for this change and consistently started getting "complete" statuses (tested this many times, seems to be reproducible behavior).
```
COPY image_utils.py /home/eden/.local/lib/python3.10/site-packages/eden/image_utils.py
```

Full `Dockerfile` for context (`server.py` is the `not_so_minimal` example...)

```
FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime

RUN apt-get update && apt-get install -y \
    libgl1-mesa-glx \
    libglib2.0-0 \
    && rm -rf /var/lib/apt/lists/*

# for gitpython (TODO: can we remove this requirement somehow? Or work with it as a design constraint?)
RUN apt-get update && apt-get install -y \
    git \
    && rm -rf /var/lib/apt/lists/*

WORKDIR /app
RUN useradd -ms /bin/bash eden
RUN chown eden:eden /app

USER eden
ENV PATH="/home/eden/.local/bin:${PATH}"
RUN pip install eden-python
COPY server.py .
# attempted bugfix
COPY image_utils.py /home/eden/.local/lib/python3.10/site-packages/eden/image_utils.py

EXPOSE 5656
# hack around gitpython until better solution (PR?) presents itself
RUN git init .
RUN git config --global user.email "none@site.com"
RUN git config --global user.name "eden-service-user"
# add fake remote upstream bc the above gets you past git.exc exception only to hit AttributeError for a missing remote
RUN git remote add origin https://git.clfx.cc/mm/eden-app.git
RUN git add server.py
RUN git commit -am "initial commit"

CMD ["python", "server.py"]
```